### PR TITLE
Add missing CloudFlare IP Range to cloudflare.conf

### DIFF
--- a/SOURCES/cloudflare.conf
+++ b/SOURCES/cloudflare.conf
@@ -2,6 +2,6 @@ LoadModule cloudflare_module modules/mod_cloudflare.so
 
 <IfModule mod_cloudflare.c>
 	CloudFlareRemoteIPHeader CF-Connecting-IP
-	CloudFlareRemoteIPTrustedProxy 204.93.240.0/24 204.93.177.0/24 199.27.128.0/21 173.245.48.0/20 103.22.200.0/22 141.101.64.0/18 108.162.192.0/18 172.64.0.0/13
+	CloudFlareRemoteIPTrustedProxy 103.21.244.0/22 103.22.200.0/22 103.31.4.0/22 104.16.0.0/12 108.162.192.0/18 131.0.72.0/22 141.101.64.0/18 162.158.0.0/15 172.64.0.0/13 173.245.48.0/20 188.114.96.0/20 190.93.240.0/20 197.234.240.0/22 198.41.128.0/17 199.27.128.0/21
 	#DenyAllButCloudFlare
 </IfModule>

--- a/SOURCES/cloudflare.conf
+++ b/SOURCES/cloudflare.conf
@@ -2,6 +2,6 @@ LoadModule cloudflare_module modules/mod_cloudflare.so
 
 <IfModule mod_cloudflare.c>
 	CloudFlareRemoteIPHeader CF-Connecting-IP
-	CloudFlareRemoteIPTrustedProxy 204.93.240.0/24 204.93.177.0/24 199.27.128.0/21 173.245.48.0/20 103.22.200.0/22 141.101.64.0/18 108.162.192.0/18
+	CloudFlareRemoteIPTrustedProxy 204.93.240.0/24 204.93.177.0/24 199.27.128.0/21 173.245.48.0/20 103.22.200.0/22 141.101.64.0/18 108.162.192.0/18 172.64.0.0/13
 	#DenyAllButCloudFlare
 </IfModule>


### PR DESCRIPTION
After speaking with CloudFlare support regarding EA4 support, they specifically told me to make sure that when using this repo, that the new IP ranges were in the configuration, specifically `172.64.0.0/13`

You can verify this is a legit CloudFlare IPv4 subnet here:
https://www.cloudflare.com/ips-v4
